### PR TITLE
add support for OpenSearch

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
 		<meta property="og:type" content="website">
 		<meta property="og:url" content="bower.io/search">
 		<meta property="og:image" content="http://bower.io/img/bower-logo.png">
+    <link title="Bower.io" type="application/opensearchdescription+xml" href="http://bower.io/opensearch.xml" rel="search">
 		<title>Bower - Search</title>
 		<link href="dist/app.css" rel="stylesheet">
 		<style>

--- a/opensearch.xml
+++ b/opensearch.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/" xmlns:moz="http://www.mozilla.org/2006/browser/search/">
+  <ShortName>Bower</ShortName>
+  <LongName>Search on Bower.io</LongName>
+  <Description>Search packages on Bower.io</Description>
+  <Tags>bower js javascript repository packages distribution</Tags>
+  <Language>en-us</Language>
+  <Contact>opensource@twitter.com</Contact>
+  <OutputEncoding>UTF-8</OutputEncoding>
+  <InputEncoding>UTF-8</InputEncoding>
+  <Url type="text/html" method="get" template="http://bower.io/search/?q={searchTerms}"/>
+  <moz:SearchForm>http://bower.io/search/</moz:SearchForm>
+  <Developer>Bower</Developer>
+  <AdultContent>false</AdultContent>
+  <Image height="64" width="64" type="image/png">https://avatars3.githubusercontent.com/u/3709251?v=3&s=64</Image>
+  <Image height="16" width="16" type="image/vnd.microsoft.icon">http://bower.io/favicon.ico</Image>
+</OpenSearchDescription>


### PR DESCRIPTION
OpenSearch on Bower site adds the ability to use http://bower.io/search in your browser's search-engine bar


http://www.opensearch.org
https://developer.mozilla.org/en-US/Add-ons/Creating_OpenSearch_plugins_for_Firefox